### PR TITLE
Fix Chrome and Helium detection on macOS

### DIFF
--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -71,8 +71,6 @@ export async function findChromeWidevinePath(): Promise<string | null> {
       const versionsPath = join(
         dirname(chromePath),
         "..",
-        "..",
-        "..",
         "Frameworks",
         "Google Chrome Framework.framework",
         "Versions"
@@ -80,40 +78,55 @@ export async function findChromeWidevinePath(): Promise<string | null> {
 
       log.info(`Scanning Chrome Versions directory: ${versionsPath}`);
 
-      const entries = await readdir(versionsPath, { withFileTypes: true });
+      let entries: any[] = [];
+      try {
+        entries = await readdir(versionsPath, { withFileTypes: true });
+      } catch (err) {
+        log.info(`✗ Failed to read Versions directory: ${versionsPath}`);
+      }
 
       for (const entry of entries) {
         if (entry.isDirectory() && /^\d+\.\d+\.\d+\.\d+$/.test(entry.name)) {
-          const versionWidevine = join(
-            versionsPath,
-            entry.name,
-            "WidevineCdm.plugin"
-          );
-          log.info(`Checking path: ${versionWidevine}`);
-          try {
-            const stats = await stat(versionWidevine);
-            if (stats.isDirectory()) {
-              log.info(`✓ Found WidevineCdm at: ${versionWidevine}`);
-              widevinePath = versionWidevine;
-              break;
+          // Check for both modern (Libraries/WidevineCdm) and legacy (WidevineCdm.plugin) paths
+          const pathsToTry = [
+            join(versionsPath, entry.name, "Libraries", "WidevineCdm"),
+            join(versionsPath, entry.name, "WidevineCdm.plugin"),
+          ];
+
+          for (const versionWidevine of pathsToTry) {
+            log.info(`Checking path: ${versionWidevine}`);
+            try {
+              const stats = await stat(versionWidevine);
+              if (stats.isDirectory()) {
+                log.info(`✓ Found WidevineCdm at: ${versionWidevine}`);
+                widevinePath = versionWidevine;
+                break;
+              }
+            } catch {
+              log.info(`✗ Path does not exist: ${versionWidevine}`);
             }
-          } catch {
-            log.info(`✗ Path does not exist: ${versionWidevine}`);
           }
+          if (widevinePath) break;
         }
       }
 
       if (!widevinePath) {
-        const fallbackPath = join(versionsPath, "A", "WidevineCdm.plugin");
-        log.info(`Checking fallback path: ${fallbackPath}`);
-        try {
-          const stats = await stat(fallbackPath);
-          if (stats.isDirectory()) {
-            log.info(`✓ Found WidevineCdm at: ${fallbackPath}`);
-            widevinePath = fallbackPath;
+        const fallbackPaths = [
+          join(versionsPath, "A", "Libraries", "WidevineCdm"),
+          join(versionsPath, "A", "WidevineCdm.plugin"),
+        ];
+        for (const fallbackPath of fallbackPaths) {
+          log.info(`Checking fallback path: ${fallbackPath}`);
+          try {
+            const stats = await stat(fallbackPath);
+            if (stats.isDirectory()) {
+              log.info(`✓ Found WidevineCdm at: ${fallbackPath}`);
+              widevinePath = fallbackPath;
+              break;
+            }
+          } catch {
+            log.info(`✗ Fallback path does not exist: ${fallbackPath}`);
           }
-        } catch {
-          log.info(`✗ Fallback path does not exist: ${fallbackPath}`);
         }
       }
     } else {
@@ -164,52 +177,81 @@ export async function findChromeWidevinePath(): Promise<string | null> {
 export async function findHeliumVersionPath(): Promise<string | null> {
   const log = getLogger();
   const platform = getPlatform();
-  let basePath: string;
+  let basePaths: string[] = [];
 
   if (platform === "win32") {
     const localAppData =
       process.env.LOCALAPPDATA || join(homedir(), "AppData", "Local");
-    basePath = join(localAppData, "imput", "Helium", "Application");
+    basePaths = [join(localAppData, "imput", "Helium", "Application")];
   } else if (platform === "darwin") {
-    basePath = join(
-      homedir(),
-      "Library",
-      "Application Support",
-      "Helium",
-      "Application"
-    );
+    basePaths = [
+      "/Applications/Helium.app/Contents/Frameworks/Helium Framework.framework/Versions",
+      join(
+        homedir(),
+        "Applications",
+        "Helium.app",
+        "Contents",
+        "Frameworks",
+        "Helium Framework.framework",
+        "Versions"
+      ),
+      join(
+        homedir(),
+        "Library",
+        "Application Support",
+        "Helium",
+        "Application"
+      ),
+    ];
   } else {
-    basePath = join(homedir(), ".config", "Helium", "Application");
+    basePaths = [join(homedir(), ".config", "Helium", "Application")];
   }
 
-  log.info(`Checking Helium base path: ${basePath}`);
+  for (const basePath of basePaths) {
+    log.info(`Checking Helium base path: ${basePath}`);
 
-  try {
-    const baseStats = await stat(basePath);
-    if (!baseStats.isDirectory()) {
-      log.info(`✗ Base path is not a directory: ${basePath}`);
-      return null;
+    try {
+      const baseStats = await stat(basePath);
+      if (!baseStats.isDirectory()) {
+        log.info(`✗ Base path is not a directory: ${basePath}`);
+        continue;
+      }
+    } catch {
+      log.info(`✗ Base path does not exist: ${basePath}`);
+      continue;
     }
-  } catch {
-    log.info(`✗ Base path does not exist: ${basePath}`);
-    return null;
-  }
 
-  log.info(`Scanning for Helium version folders in: ${basePath}`);
+    log.info(`Scanning for Helium version folders in: ${basePath}`);
 
-  const entries = await readdir(basePath, { withFileTypes: true });
+    try {
+      const entries = await readdir(basePath, { withFileTypes: true });
 
-  for (const entry of entries) {
-    if (entry.isDirectory() && /^\d+\.\d+\.\d+\.\d+$/.test(entry.name)) {
-      const versionPath = join(basePath, entry.name);
+      for (const entry of entries) {
+        if (entry.isDirectory() && /^\d+\.\d+\.\d+\.\d+$/.test(entry.name)) {
+          let versionPath = join(basePath, entry.name);
 
-      log.info(`✓ Found Helium version folder: ${versionPath}`);
-      return versionPath;
+          // If we're inside a Framework, we might need to go into Libraries
+          const librariesPath = join(versionPath, "Libraries");
+          try {
+            const libStats = await stat(librariesPath);
+            if (libStats.isDirectory()) {
+              log.info(`✓ Found Libraries directory in Helium: ${librariesPath}`);
+              versionPath = librariesPath;
+            }
+          } catch {
+            // No Libraries folder, use versionPath directly
+          }
+
+          log.info(`✓ Found Helium version folder: ${versionPath}`);
+          return versionPath;
+        }
+      }
+    } catch (err) {
+      log.info(`✗ Failed to read directory: ${basePath}`);
     }
   }
 
   log.info(`✗ No valid Helium version folder found`);
-
   return null;
 }
 


### PR DESCRIPTION
## Summary
This PR improves the detection logic for Google Chrome and Helium browser on macOS and ensures Widevine is copied to all potential locations Helium might look for it.

### Changes
- **Multiple Location Support:**
  - The tool now searches for and copies Widevine to ALL detected Helium installations and profiles, rather than just the first one found.
- **Chrome Detection:**
  - Corrected directory traversal to find `Google Chrome Framework.framework/Versions`.
  - Added support for both modern (`Libraries/WidevineCdm`) and legacy (`WidevineCdm.plugin`) Widevine paths.
- **Helium Detection Improvements:**
  - Added `net.imput.helium` Application Support directory to search paths (standard for Chromium-based apps on macOS).
  - Added support for `/Applications/Helium.app` and `~/Applications/Helium.app`.
  - Logic to detect and use the `Libraries` folder within the app bundle if present.
- **Robustness:**
  - Improved error handling for directory scanning.

These changes significantly increase the success rate of the fix on macOS by covering both the application bundle and the user's profile directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for discovering and handling multiple Helium/Widevine locations and applying fixes to each found installation.
  * Dry-run now reports each potential destination separately.

* **Bug Fixes**
  * Broader and more resilient library detection across OS locations.
  * Improved error handling: continues searching and processing other candidates instead of aborting.

* **Style / Logging**
  * More detailed per-location progress and outcome messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->