### PR TITLE
Add custom paths section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ bun run build
 
 If this script fails to find your browser, you can specify the path to it manually:
 
-```
-bun run cli.ts --chrome-path /usr/bin/google-chrome-stable --helium-path /usr/bin/helium-browser
+```bash
+sudo bun run cli.ts --chrome-path /usr/bin/google-chrome-stable --helium-path /usr/bin/helium-browser
 ```
 
 You can find the path on your system by running `which google-chrome-stable` on macOS and Linux.


### PR DESCRIPTION
Added instructions for specifying custom browser paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for specifying custom browser paths, including examples for the --chrome-path and --helium-path flags, plus instructions on locating your Chrome installation (e.g., using which google-chrome-stable on macOS/Linux).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->