### PR TITLE
Fix macOS and Linux support

### DIFF
--- a/commands/index.ts
+++ b/commands/index.ts
@@ -1,9 +1,13 @@
-import { findChromeWidevinePath, findHeliumVersionPath } from "../lib/paths";
+import { findChromeWidevinePath, findHeliumVersionPath, getPlatform } from "../lib/paths";
 import { copyDir } from "../lib/utils";
 import { initLogger, type Logger } from "../lib/logger";
 import { downloadAndExtractChrome } from "../lib/chrome-downloader";
 import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import ora from "ora";
+
+const execFileAsync = promisify(execFile);
 import chalk from "chalk";
 
 export interface FixHeliumDrmOptions {
@@ -138,6 +142,24 @@ export async function fixHeliumDrm(options: FixHeliumDrmOptions = {}) {
     copySpinner.fail(chalk.red("Failed to copy WidevineCdm"));
     logger.error("Failed to copy WidevineCdm", { error });
     process.exit(1);
+  }
+
+  if (getPlatform() === "darwin") {
+    const signSpinner = ora("Re-signing Helium.app to include WidevineCdm...").start();
+    logger.info("Re-signing Helium.app after modifying framework contents...");
+
+    try {
+      const heliumAppPath = "/Applications/Helium.app";
+      await execFileAsync("xattr", ["-cr", heliumAppPath]);
+      await execFileAsync("codesign", ["--force", "--deep", "--sign", "-", heliumAppPath]);
+      signSpinner.succeed(chalk.green("Helium.app re-signed successfully"));
+      logger.info("Helium.app re-signed successfully");
+    } catch (error) {
+      signSpinner.fail(chalk.red("Failed to re-sign Helium.app"));
+      logger.error("Failed to re-sign Helium.app", { error });
+      console.log(chalk.yellow("\n⚠️  You may need to run with sudo, or manually run:"));
+      console.log(chalk.dim('   codesign --force --deep --sign - "/Applications/Helium.app"\n'));
+    }
   }
 
   console.log(

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -1,8 +1,9 @@
-import { findChromeWidevinePath, findHeliumVersionPath, getPlatform } from "../lib/paths";
+import { findChromeWidevinePath, findHeliumVersionPath, findHeliumUserDataDir, getPlatform } from "../lib/paths";
 import { copyDir } from "../lib/utils";
 import { initLogger, type Logger } from "../lib/logger";
 import { downloadAndExtractChrome } from "../lib/chrome-downloader";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import ora from "ora";
@@ -110,7 +111,28 @@ export async function fixHeliumDrm(options: FixHeliumDrmOptions = {}) {
     options
   );
 
-  const heliumWidevinePath = join(heliumVersionPath, "WidevineCdm");
+  let heliumWidevinePath: string;
+
+  if (getPlatform() === "linux") {
+    // On Linux, Chromium loads WidevineCdm from the user data directory
+    // using the component updater format: <user-data>/WidevineCdm/<version>/
+    const manifest = JSON.parse(
+      await readFile(join(chromeWidevinePath, "manifest.json"), "utf-8")
+    );
+    const version: string = manifest.version;
+    const userDataDir = await findHeliumUserDataDir();
+
+    if (!userDataDir) {
+      console.log(chalk.red("\n✗ Could not find Helium user data directory."));
+      console.log(chalk.yellow("  Please launch Helium at least once before running this tool.\n"));
+      process.exit(1);
+    }
+
+    heliumWidevinePath = join(userDataDir, "WidevineCdm", version);
+    logger.info(`Using Linux component updater path: ${heliumWidevinePath}`);
+  } else {
+    heliumWidevinePath = join(heliumVersionPath, "WidevineCdm");
+  }
 
   if (options.check) {
     console.log(chalk.bold.green("\n✅ Check complete. Fix can be applied.\n"));
@@ -136,6 +158,14 @@ export async function fixHeliumDrm(options: FixHeliumDrmOptions = {}) {
 
   try {
     await copyDir(chromeWidevinePath, heliumWidevinePath);
+
+    // On Linux, write the component updater hint file so Chromium finds the CDM
+    if (getPlatform() === "linux") {
+      const hintFile = join(dirname(heliumWidevinePath), "latest-component-updated-widevine-cdm");
+      await writeFile(hintFile, JSON.stringify({ Path: heliumWidevinePath }));
+      logger.info(`Wrote hint file: ${hintFile}`);
+    }
+
     copySpinner.succeed(chalk.green("WidevineCdm copied successfully!"));
     logger.info("WidevineCdm copied successfully!");
   } catch (error) {

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -1,7 +1,7 @@
 import { BrowserFinder } from "@agent-infra/browser-finder";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
-import { readdir, stat } from "node:fs/promises";
+import { readdir, stat, realpath } from "node:fs/promises";
 import { getLogger } from "./logger";
 
 export interface PlatformPaths {
@@ -103,9 +103,21 @@ export async function findChromeWidevinePath(): Promise<string | null> {
       }
     } else {
       const chromePath = chrome.path;
-      const chromeDir = dirname(chromePath);
-      const directPath = join(chromeDir, "WidevineCdm");
+      let chromeDir = dirname(chromePath);
 
+      // On Linux, chrome.path is often a wrapper script in /usr/bin.
+      // Try resolving symlinks to find the real Chrome install directory.
+      try {
+        const resolved = await realpath(chromePath);
+        if (resolved !== chromePath) {
+          chromeDir = dirname(resolved);
+          log.info(`Resolved Chrome symlink to: ${chromeDir}`);
+        }
+      } catch {
+        // ignore - continue with original path
+      }
+
+      const directPath = join(chromeDir, "WidevineCdm");
       log.info(`Checking direct path: ${directPath}`);
 
       try {
@@ -132,6 +144,29 @@ export async function findChromeWidevinePath(): Promise<string | null> {
             } catch {
               log.info(`✗ Path does not exist: ${versionPath}`);
             }
+          }
+        }
+      }
+
+      // Fallback: check well-known Linux Chrome installation directories
+      if (!widevinePath) {
+        const knownPaths = [
+          "/opt/google/chrome/WidevineCdm",
+          "/opt/google/chrome-beta/WidevineCdm",
+          "/usr/lib/chromium/WidevineCdm",
+          "/usr/lib/chromium-browser/WidevineCdm",
+        ];
+        for (const knownPath of knownPaths) {
+          log.info(`Checking known Chrome path: ${knownPath}`);
+          try {
+            const stats = await stat(knownPath);
+            if (stats.isDirectory()) {
+              log.info(`✓ Found WidevineCdm at: ${knownPath}`);
+              widevinePath = knownPath;
+              break;
+            }
+          } catch {
+            log.info(`✗ Path does not exist: ${knownPath}`);
           }
         }
       }
@@ -165,6 +200,11 @@ export async function findHeliumVersionPath(): Promise<string | null> {
       "Versions"
     );
   } else {
+    // Linux: check system package installations first
+    const systemInstall = await findHeliumLinuxInstall(log);
+    if (systemInstall) return systemInstall;
+
+    // Fall back to user config path with version subdirectories
     basePath = join(homedir(), ".config", "Helium", "Application");
   }
 
@@ -198,6 +238,84 @@ export async function findHeliumVersionPath(): Promise<string | null> {
   }
 
   log.info(`✗ No valid Helium version folder found`);
+
+  return null;
+}
+
+/**
+ * Find Helium's user data directory on Linux.
+ * Chromium loads WidevineCdm from the user data dir using the component updater format.
+ */
+export async function findHeliumUserDataDir(): Promise<string | null> {
+  const log = getLogger();
+  const candidates = [
+    join(homedir(), ".config", "net.imput.helium"),
+    join(homedir(), ".config", "Helium"),
+    join(homedir(), ".config", "helium"),
+  ];
+
+  for (const dir of candidates) {
+    log.info(`Checking Helium user data dir: ${dir}`);
+    try {
+      const stats = await stat(dir);
+      if (stats.isDirectory()) {
+        log.info(`✓ Found Helium user data dir: ${dir}`);
+        return dir;
+      }
+    } catch {
+      log.info(`✗ Path does not exist: ${dir}`);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Find Helium system installation on Linux.
+ * Handles flat directory layouts (e.g. /opt/helium-browser-bin/) used by
+ * distro packages where there are no version subdirectories.
+ */
+async function findHeliumLinuxInstall(
+  log: ReturnType<typeof getLogger>
+): Promise<string | null> {
+  const candidates: string[] = [];
+
+  // Try resolving the helium-browser binary symlink to find the install dir
+  for (const binPath of ["/usr/bin/helium-browser", "/usr/bin/helium"]) {
+    try {
+      const resolved = await realpath(binPath);
+      const dir = dirname(resolved);
+      if (!candidates.includes(dir)) {
+        candidates.push(dir);
+      }
+    } catch {
+      // not found
+    }
+  }
+
+  // Known system package locations
+  if (!candidates.includes("/opt/helium-browser-bin")) {
+    candidates.push("/opt/helium-browser-bin");
+  }
+
+  for (const candidate of candidates) {
+    log.info(`Checking Linux Helium system path: ${candidate}`);
+    try {
+      const stats = await stat(candidate);
+      if (!stats.isDirectory()) continue;
+
+      // Verify this is a Helium installation by checking for the helium binary
+      try {
+        await stat(join(candidate, "helium"));
+        log.info(`✓ Found Helium system installation: ${candidate}`);
+        return candidate;
+      } catch {
+        log.info(`✗ No helium binary in: ${candidate}`);
+      }
+    } catch {
+      log.info(`✗ Path does not exist: ${candidate}`);
+    }
+  }
 
   return null;
 }

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -71,8 +71,6 @@ export async function findChromeWidevinePath(): Promise<string | null> {
       const versionsPath = join(
         dirname(chromePath),
         "..",
-        "..",
-        "..",
         "Frameworks",
         "Google Chrome Framework.framework",
         "Versions"
@@ -87,7 +85,8 @@ export async function findChromeWidevinePath(): Promise<string | null> {
           const versionWidevine = join(
             versionsPath,
             entry.name,
-            "WidevineCdm.plugin"
+            "Libraries",
+            "WidevineCdm"
           );
           log.info(`Checking path: ${versionWidevine}`);
           try {
@@ -100,20 +99,6 @@ export async function findChromeWidevinePath(): Promise<string | null> {
           } catch {
             log.info(`✗ Path does not exist: ${versionWidevine}`);
           }
-        }
-      }
-
-      if (!widevinePath) {
-        const fallbackPath = join(versionsPath, "A", "WidevineCdm.plugin");
-        log.info(`Checking fallback path: ${fallbackPath}`);
-        try {
-          const stats = await stat(fallbackPath);
-          if (stats.isDirectory()) {
-            log.info(`✓ Found WidevineCdm at: ${fallbackPath}`);
-            widevinePath = fallbackPath;
-          }
-        } catch {
-          log.info(`✗ Fallback path does not exist: ${fallbackPath}`);
         }
       }
     } else {
@@ -172,11 +157,12 @@ export async function findHeliumVersionPath(): Promise<string | null> {
     basePath = join(localAppData, "imput", "Helium", "Application");
   } else if (platform === "darwin") {
     basePath = join(
-      homedir(),
-      "Library",
-      "Application Support",
-      "Helium",
-      "Application"
+      "/Applications",
+      "Helium.app",
+      "Contents",
+      "Frameworks",
+      "Helium Framework.framework",
+      "Versions"
     );
   } else {
     basePath = join(homedir(), ".config", "Helium", "Application");
@@ -201,7 +187,10 @@ export async function findHeliumVersionPath(): Promise<string | null> {
 
   for (const entry of entries) {
     if (entry.isDirectory() && /^\d+\.\d+\.\d+\.\d+$/.test(entry.name)) {
-      const versionPath = join(basePath, entry.name);
+      const versionPath =
+        platform === "darwin"
+          ? join(basePath, entry.name, "Libraries")
+          : join(basePath, entry.name);
 
       log.info(`✓ Found Helium version folder: ${versionPath}`);
       return versionPath;


### PR DESCRIPTION
## Summary
- **macOS**: Correct Chrome/Helium paths and add code re-signing after copying WidevineCdm
- **Linux**: Fix Chrome and Helium path detection, use Chromium component updater format for WidevineCdm

## macOS fixes
- Fix Chrome path traversal to correctly reach `Contents/Frameworks/`
- Update WidevineCdm location from `WidevineCdm.plugin` to `Libraries/WidevineCdm` (modern Chrome)
- Fix Helium path to use `/Applications/Helium.app/Contents/Frameworks/Helium Framework.framework/Versions`
- Add `codesign --force --deep --sign -` re-signing step after copying (required by macOS security)

## Linux fixes
- Add fallback to well-known Chrome paths (`/opt/google/chrome/WidevineCdm`, etc.) since `BrowserFinder` returns wrapper scripts in `/usr/bin/` whose `dirname` doesn't contain WidevineCdm
- Detect Helium system package installs by resolving `/usr/bin/helium-browser` symlink and checking `/opt/helium-browser-bin/`
- Use Chromium's **component updater format**: copy WidevineCdm to `~/.config/net.imput.helium/WidevineCdm/<version>/` and write the `latest-component-updated-widevine-cdm` hint file — this is how Chromium actually loads the CDM
- No sudo required on Linux (writes to user data directory)
- Detect Helium user data dir across naming variants (`net.imput.helium`, `Helium`, `helium`)

## Test plan
- [x] Tested on macOS — YouTube TV plays Widevine-protected content (Chrome 144, Helium 144)
- [x] Tested on Linux (Arch) — YouTube TV works after running without sudo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux support for detecting and updating DRM components and locating app data/install paths; writes updater hint to aid Chromium component updates.

* **Bug Fixes**
  * Improved macOS reliability by automatically clearing extended attributes and re-signing the app after DRM updates; better error messaging and recovery hints.

* **Chores**
  * Enhanced cross-platform path discovery and logging for more robust installation and upgrade flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->